### PR TITLE
Properly generate stub for x64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 project(milesstub VERSION 1.0.0 LANGUAGES C)
 
 add_library(milescleanup STATIC cleanup.c)
-add_library(milesstub SHARED miles.c miles.def)
+add_library(milesstub SHARED miles.c)
 set_target_properties(milesstub PROPERTIES OUTPUT_NAME mss32)
 set_target_properties(milesstub PROPERTIES SOVERSION 1.0 VERSION 1.0.0)
 target_include_directories(milesstub PUBLIC

--- a/mss/mss.h
+++ b/mss/mss.h
@@ -143,10 +143,14 @@ typedef void(__stdcall *AIL_stream_callback)(HSTREAM);
 typedef void(__stdcall *AIL_3dsample_callback)(H3DPOBJECT);
 typedef void(__stdcall *AIL_sample_callback)(HSAMPLE);
 
-#if !defined BUILD_STUBS && defined _WIN32
-#define IMPORTS __declspec(dllimport)
+#if defined _WIN32
+    #if !defined BUILD_STUBS
+    #define IMPORTS __declspec(dllimport)
+    #else
+    #define IMPORTS __declspec(dllexport)
+    #endif
 #else
-#define IMPORTS
+    #define IMPORTS
 #endif
 
 #define DIG_USE_WAVEOUT 15


### PR DESCRIPTION
When building the stubs for x64, at least with clang, this results in a linker error, when the def file is used.
Export the symbols using attribute dllexport.